### PR TITLE
feat: add user data collection

### DIFF
--- a/backend/api/db_models.py
+++ b/backend/api/db_models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, Table
+from sqlalchemy import JSON, Column, Integer, String, ForeignKey, Table
 from sqlalchemy.orm import relationship
 from .database import Base
 
@@ -10,6 +10,7 @@ user_images = Table(
     Column("image_id", Integer, ForeignKey("images.id"), primary_key=True),
 )
 
+
 class User(Base):
     __tablename__ = "users"
     id = Column(Integer, primary_key=True, nullable=False)
@@ -17,6 +18,21 @@ class User(Base):
     found_in_images = relationship(
         "Image", secondary=user_images, back_populates="users_found_in"
     )
+    user_data = relationship(
+        "UserFaceAndResult", back_populates="user", cascade="all, delete-orphan"
+    )
+
+
+class UserFaceAndResult(Base):
+    __tablename__ = "user_face_and_result"
+    id = Column(Integer, primary_key=True, nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    user_face_path = Column(String, nullable=False)
+    clusters = Column(JSON, nullable=True)
+    confidences = Column(JSON, nullable=True)
+
+    user = relationship("User", back_populates="user_data")
+
 
 class Image(Base):
     __tablename__ = "images"


### PR DESCRIPTION
I've added a new table to the DB to store the following data:
- user ID
- user's cropped face path (storing embeddings would not be easy to scale up and cannot be used on new sets of images. Storing the original cropped image will allow us to easily generate embeddings for different sets of images but comes at the cost of about ~10Kb of storage per user)
- day-wise cluster location for that user (predicted)
- day-wise similarity scores for the prediction

Note: the cropped face will be stored on the backend itself