### PR TITLE
feat: endpoint for marking images as false positive

### DIFF
--- a/backend/api/db_models.py
+++ b/backend/api/db_models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import JSON, Column, Integer, String, ForeignKey, Table
+from sqlalchemy import JSON, Boolean, Column, Integer, String, ForeignKey, Table
 from sqlalchemy.orm import relationship
 from .database import Base
 
@@ -8,6 +8,7 @@ user_images = Table(
     Base.metadata,
     Column("user_id", Integer, ForeignKey("users.id"), primary_key=True),
     Column("image_id", Integer, ForeignKey("images.id"), primary_key=True),
+    Column("false_positive", Boolean, default=False, nullable=False),
 )
 
 


### PR DESCRIPTION
- ``/get_user_results`` returns images that are not marked as false positives
- ``/false_positive/{image_name}`` Marks an image as a false positive for the user. It takes the image name as a path parameter and marks it as a false positive in the database.